### PR TITLE
chore: speakeasy migrate

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -1,33 +1,26 @@
 name: Generate
 permissions:
-  checks: write
-  contents: write
-  pull-requests: write
-  statuses: write
-on:
-  workflow_dispatch:
-    inputs:
-      force:
-        description: "Force the generation of the SDKs"
-        type: boolean
-        default: false
-  schedule:
-    - cron: 0 0 * * *
-
+    checks: write
+    contents: write
+    pull-requests: write
+    statuses: write
+"on":
+    workflow_dispatch:
+        inputs:
+            force:
+                description: Force the generation of the SDKs
+                type: boolean
+                default: false
+    schedule:
+        - cron: 0 0 * * *
 jobs:
-  generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-generation.yaml@v14
-    with:
-      speakeasy_version: latest
-      openapi_docs: |
-        - https://insulator.conductor.one/api/v1/openapi.yaml
-      languages: |-
-        - python
-      mode: pr
-      publish_python: false
-      force: ${{ github.event.inputs.force }}
-    secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
-      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-  
+    generate:
+        uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+        with:
+            force: ${{ github.event.inputs.force }}
+            mode: pr
+            speakeasy_version: latest
+        secrets:
+            github_access_token: ${{ secrets.GITHUB_TOKEN }}
+            slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+            speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,0 +1,9 @@
+workflowVersion: 1.0.0
+sources:
+    my-source:
+        inputs:
+            - location: https://insulator.conductor.one/api/v1/openapi.yaml
+targets:
+    conductorone-python:
+        target: python
+        source: my-source


### PR DESCRIPTION
This PR is the set of changes created from speakeasy migrate . Docs here: https://www.speakeasyapi.dev/docs/workflow-migration

Merging this migration enables:

- Local use of `speakeasy run` which emulates github generation locally
- linting reports
- breaking change reports on API changes

No code changes as a result of this migration